### PR TITLE
Don't dispatch to pulumi/registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,20 +119,6 @@ jobs:
         - dotnet
         - go
         - java
-  create_docs_build:
-    name: create_docs_build
-    needs: tag_sdk
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-      name: Dispatch Event
-      run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
-        "${GITHUB_REF#refs/tags/}"
   lint:
     container: golangci/golangci-lint:v1.51
     name: lint


### PR DESCRIPTION
These calls always fail, so this change just removes them.
